### PR TITLE
Update Aliyun.Api.LogService.csproj

### DIFF
--- a/Aliyun.Api.LogService/Aliyun.Api.LogService.csproj
+++ b/Aliyun.Api.LogService/Aliyun.Api.LogService.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/aliyun/aliyun-log-dotnetcore-sdk</PackageProjectUrl>
     <PackageTags>Aliyun </PackageTags>
     <Title>Aliyun LogService .Net Core SDK</Title>
-    <PackOnBuild>true</PackOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageVersion>1.1.0</PackageVersion>
     <Description>Aliyun LogService SDK for .NET Core.</Description>
   </PropertyGroup>
@@ -19,6 +19,10 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign>false</PublicSign>
     <AssemblyOriginatorKeyFile>$(SolutionDir)\aliyun-log-dotnetcore-sdk.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />


### PR DESCRIPTION
从nuget安装这个包时，发现调用的方法和实体类都没有提示信息，这样在开发的时候需要同时打开文档对照方法和方法的参数含义。

![image](https://user-images.githubusercontent.com/8394988/79970423-784da680-84c5-11ea-82f3-8dc3d11864a2.png)

源码里面对这些方法和参数都是有注释的，nuget包里面没有包含对应的xml文件，设置`GenerateDocumentationFile`为true可以解决这个问题。